### PR TITLE
Add version restriction on astropy so stistools will install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     package_dir = {"ullyses": "ullyses"},
     install_requires = ["setuptools",
                         "numpy",
-                        "astropy",
+                        "astropy<=4.3.1",
 						"ullyses_utils",
                         "stistools>=1.4.1",
                         "pandas",


### PR DESCRIPTION
This change is needed for the STIS recalibration folks. Stopgap solution until stistools is fixed (see https://github.com/spacetelescope/stistools/issues/139)

Should be an easy PR, if it can be approved in the next day it would be appreciated.