### PR TITLE
Calibrate one or more STIS exposures per grating

### DIFF
--- a/ullyses/calibrate_stis_data.py
+++ b/ullyses/calibrate_stis_data.py
@@ -78,8 +78,10 @@ class StisData:
         config = read_config(yamlfile)
         infile_name = os.path.basename(infile)
         self.force_dq16 = config["force_dq16"]
-        self.target_dict = config["infiles"][infile_name]["targets"]
-        
+        if isinstance(config["infile"], dict):
+            self.target_dict = config["infile"][infile_name]["targets"]
+        else:
+            self.target_dict = config["targets"]
         self.infile = infile
         self.basedir = os.path.dirname(self.infile)
         if outdir is None:
@@ -717,7 +719,10 @@ def calibrate_stis_data(indir, yamlfile, dolog=True, logfile=None, outdir=None,
     if "." in outdir:
         raise ValueError("Rename output directory to remove period characters")
     config = read_config(yamlfile)
-    infiles = list(config["infiles"].keys())
+    if isinstance(config["infile"], dict):
+        infiles = list(config["infile"].keys())
+    else:
+        infiles = [config["infile"]]
     for item in infiles:
         infile = os.path.join(indir, item)
         if not os.path.exists(infile):


### PR DESCRIPTION
Previously, the STIS recalibration code required a YAML file that listed only one input file to recalibrate per grating. There was no way to specify multiple files, since we only take 1 observation per grating for ULLYSES targets.

However, some TTS did not pass BOP checks for COS, so instead, multiple STIS/G140L and STIS/G230L exposures were taken to get the required wavelength coverage. This required a change to support the calibration of multiple files per grating.

These updates allow for the calibration of one or more files per grating by changing the YAML file structure (and read-in of that file). 

I have tested this myself but will assign Svea since she had a target that was previously failing. 