### PR TITLE
Fix specification of Python version in github actions workflow

### DIFF
--- a/.github/workflows/python_testing.yml
+++ b/.github/workflows/python_testing.yml
@@ -25,7 +25,7 @@ jobs:
         include:
           - name: Python 3.10
             runs-on: ubuntu-latest
-            python-version: 3.10
+            python-version: '3.10'
             toxenv: py310
 
           - name: Python 3.9


### PR DESCRIPTION
Need quotes around python version if it's >= 3.10