### PR TITLE
Changes to support both serendipitous timeseries and AR data timeseries

### DIFF
--- a/ullyses/coadd.py
+++ b/ullyses/coadd.py
@@ -129,7 +129,6 @@ class SegmentList:
                                 fppos = hdr0['FPPOS']
                                 if hasattr(self, "bad_segments"):
                                     if cenwave in self.bad_segments and self.bad_segments[cenwave] == row['SEGMENT']:
-                                        print(f"Skipped bad segment {cenwave}/{row['SEGMENT']}")
                                         continue
 
                             segment = Segment()

--- a/ullyses/coadd.py
+++ b/ullyses/coadd.py
@@ -13,7 +13,6 @@ RESET = "\033[0;0m"
 
 
 STIS_NON_CCD_DETECTORS = ['FUV-MAMA', 'NUV-MAMA']
-BAD_SEGMENTS = {2635: 'NUVC', 2950: 'NUVC'}
 
 class SegmentList:
 
@@ -128,8 +127,10 @@ class SegmentList:
                             if self.instrument == 'COS':
                                 cenwave = hdr0['CENWAVE']
                                 fppos = hdr0['FPPOS']
-                                if cenwave in BAD_SEGMENTS and BAD_SEGMENTS[cenwave] == row['SEGMENT']:
-                                    continue
+                                if hasattr(self, "bad_segments"):
+                                    if cenwave in self.bad_segments and self.bad_segments[cenwave] == row['SEGMENT']:
+                                        print(f"Skipped bad segment {cenwave}/{row['SEGMENT']}")
+                                        continue
 
                             segment = Segment()
                             segment.data = row

--- a/ullyses/ctts_cal.py
+++ b/ullyses/ctts_cal.py
@@ -532,7 +532,8 @@ def monitoring_star(datadir, orig_datadir, tss_outdir, targ, yamlfile=None, cust
     move_input_epoch_data(datadir, tss_params)
     create_splittags(datadir, tss_params)
     move_output_epoch_data(datadir, tss_params)
-    correct_vignetting(datadir)
+    if "g230l" in tss_params["gratings"]:
+        correct_vignetting(datadir)
     create_monitoring_timeseries(datadir, tss_outdir, targ, tss_params)
 
 

--- a/ullyses/ctts_cal.py
+++ b/ullyses/ctts_cal.py
@@ -1,3 +1,10 @@
+"""
+Wrapper to make timeseries products, both subexposure and exposure level.
+If exposure level -> the input should be the 1D spectra
+If subexposure level -> the input should be raw + spt + asn files, so that the files can be split
+and recalibrated to make subexposure x1ds.
+"""
+
 import argparse
 import numpy as np
 from astropy.io import fits
@@ -15,29 +22,54 @@ from ullyses_utils.readwrite_yaml import read_config
 UTILS_DIR = ullyses_utils.__path__[0]
 
 
-def get_bad_exposures(tss_params):
-    bad_files = tss_params["bad_files"]
-    bad_ipppss = []
-    bad_ipppssoot = []
-    if bad_files is None:
-        bad_ipppss.append(None)
-        bad_ipppssoot.append(None)
-    else:
-        for item in bad_files:
-            if len(item) == 9:
-                bad_ipppssoot.append(item)
-            elif len(item) == 7 and "*" in item:
-                ipppss = item.strip("*")
-                bad_ipppss.append(ipppss)
-            elif len(item) == 6:
-                bad_ipppss.append(item)
-    tss_params["bad_ipppss"] = bad_ipppss
-    tss_params["bad_ipppssoot"] = bad_ipppssoot
+def get_goodbad_exposures(tss_params):
+    """Determine if there are any bad exposures to avoid.
+
+    Args:
+        tss_params (dict): A dictionary where keys are the TSS parameters and
+            values are the parameter values, e.g. files to use.
+
+    Returns:
+        tss_params (dict): A dictionary where keys are the TSS parameters and
+            values are the parameter values, e.g. files to use. This has been
+            updated to explicitly list bad IPPPSS and IPPPSSOOT separately.
+    """
+    for filetype in ["bad", "good"]:
+        filetype_files = tss_params[f"{filetype}_files"]
+        filetype_ipppss = []
+        filetype_ipppssoot = []
+        if filetype_files is None:
+            filetype_ipppss.append(None)
+            filetype_ipppssoot.append(None)
+        else:
+            for item in filetype_files:
+                if len(item) == 9:
+                    filetype_ipppssoot.append(item)
+                elif len(item) == 7 and "*" in item:
+                    ipppss = item.strip("*")
+                    filetype_ipppss.append(ipppss)
+                elif len(item) == 6:
+                    filetype_ipppss.append(item)
+        tss_params[f"{filetype}_ipppss"] = filetype_ipppss
+        tss_params[f"{filetype}_ipppssoot"] = filetype_ipppssoot
     
     return tss_params
 
 
 def read_tss_yaml(targ, yamlfile=None):
+    """ Open the YAML file for the target to read TSS parameters.
+
+    Args:
+        targ (str): Name of target. Must be the ULLYSES DP target name!!!
+        yamlfile (str or None): (Optional) The name of the yamlfile to use for
+            the supplied target. If none is specified, it will be looked up
+            on the fly from the ullyses_utils repository.
+
+    Returns:
+        tss_params (dict): A dictionary where keys are the TSS parameters and
+            values are the parameter values, e.g. files to use.
+    """
+
     if yamlfile is None:
         yamlfile = os.path.join(UTILS_DIR, f"data/timeseries/{targ}.yaml")
         assert os.path.exists(yamlfile), f"YAML file not found for {targ}, expected {yamlfile}"
@@ -47,6 +79,17 @@ def read_tss_yaml(targ, yamlfile=None):
 
 
 def replace_utils_dir(shift_file, utils_dir=UTILS_DIR):
+    """Replace the $UTILS_DIR variable with the absolute path.
+
+    Args:
+        shift_file (str): The path to the wavelength shift file which includes
+            a $UTILS_DIR reference.
+        utils_dir (str): The absolute path to the ullyses_utils repository.
+    Returns:
+        shift_file (str): Updated shift_file variable with the absolute utils
+            path.
+    """
+
     spl = shift_file.split("/")
     if "$UTILS_DIR" in spl:
         ind = spl.index("$UTILS_DIR")
@@ -55,21 +98,31 @@ def replace_utils_dir(shift_file, utils_dir=UTILS_DIR):
     return shift_file
 
 
-def copy_origdata(datadir, orig_datadir, tss_params):
+def copy_serendipitous_origdata(datadir, orig_datadir, tss_params):
     """
+    NOT CURRENTLY IN USE.
+    For serendipitous stars.
     Copy the original raw data, to ensure nothing is mistakenly edited.
     Data is copied from orig_datadir to datadir.
 
     Args:
         datadir (str): Destination directory to copy data into
         orig_datadir (str): Path to the original raw data
+        tss_params (dict): A dictionary where keys are the TSS parameters and
+            values are the parameter values, e.g. files to use.
+    Returns:
+        datadir (str): The path where data were copied to. Sometimes this
+            directory is created on the fly. 
     """
 
-    files = glob.glob(os.path.join(orig_datadir, "l*corrtag*fits"))
-    files += glob.glob(os.path.join(orig_datadir, "l*rawtag*.fits"))
-    files += glob.glob(os.path.join(orig_datadir, "l*spt*.fits"))
-    files += glob.glob(os.path.join(orig_datadir, "l*asn*.fits"))
-    files += glob.glob(os.path.join(orig_datadir, "l*x1d.fits"))
+    # Covers both STIS & 
+    files = glob.glob(os.path.join(orig_datadir, "*corrtag*fits"))
+    files += glob.glob(os.path.join(orig_datadir, "*rawtag*.fits"))
+    files += glob.glob(os.path.join(orig_datadir, "*spt*.fits"))
+    files += glob.glob(os.path.join(orig_datadir, "*asn*.fits"))
+    files += glob.glob(os.path.join(orig_datadir, "*x1d.fits"))
+    files += glob.glob(os.path.join(orig_datadir, "*raw.fits"))
+    files += glob.glob(os.path.join(orig_datadir, "*sx1.fits"))
     if not os.path.exists(datadir):
         os.makedirs(datadir)
     for item in files:
@@ -84,17 +137,78 @@ def copy_origdata(datadir, orig_datadir, tss_params):
     return datadir
 
 
-def calibrate_data(datadir, tss_params, custom_caldir=None): 
+def copy_monitoring_origdata(datadir, orig_datadir, tss_params):
     """
-    Calibrate data which require special calibration. This will be for
-    any exposures which were offset in wavelength
+    For monitoring stars.
+    Copy the original raw data, to ensure nothing is mistakenly edited.
+    Data is copied from orig_datadir to datadir.
+
+    Args:
+        datadir (str): Destination directory to copy data into
+        orig_datadir (str): Path to the original raw data
+        tss_params (dict): A dictionary where keys are the TSS parameters and
+            values are the parameter values, e.g. files to use.
+    Returns:
+        datadir (str): The path where data were copied to. Sometimes this
+            directory is created on the fly. 
+    """
+
+    raws = glob.glob(os.path.join(orig_datadir, "l*rawtag*.fits"))
+
+    good_ipppss = []
+    good_ipppssoot = []
+
+    if not os.path.exists(datadir):
+        os.makedirs(datadir)
+    for item in raws:
+        basen = os.path.basename(item)
+        ipppssoot = basen[:9]
+        ipppss = basen[:6]
+        if ipppss in tss_params["bad_ipppss"] or ipppssoot in tss_params["bad_ipppssoot"]:
+            continue
+        ins = fits.getval(item, "instrume")
+        if ins.lower() != tss_params["instrument"]:
+            continue
+        grating = fits.getval(item, "opt_elem")
+        if grating.lower() not in tss_params["gratings"]:
+            continue
+        good_ipppss.append(ipppss)
+        good_ipppssoot += glob.glob(os.path.join(orig_datadir, f"{ipppssoot}*rawtag*.fits"))
+        good_ipppssoot += glob.glob(os.path.join(orig_datadir, f"{ipppssoot}*corrtag*.fits"))
+        good_ipppssoot += glob.glob(os.path.join(orig_datadir, f"{ipppssoot}*spt*.fits"))
+        good_ipppssoot += glob.glob(os.path.join(orig_datadir, f"{ipppssoot}*x1d*.fits"))
+
+    good_ipppssoot = list(set(good_ipppssoot))
+    good_ipppss = list(set(good_ipppss))
+
+    for item in good_ipppssoot:
+        shutil.copy(item, datadir)
+    asns = glob.glob(os.path.join(orig_datadir, "l*asn*.fits"))
+    for item in asns:
+        basen = os.path.basename(item)
+        ipppss = basen[:6]
+        if ipppss in good_ipppss:
+            shutil.copy(item, datadir)
+
+    print(f"\nCopied original files to {datadir}")
+
+    return datadir
+
+
+def calibrate_cos_data(datadir, tss_params, custom_caldir=None): 
+    """
+    Calibrate COS data which require special calibration. Typically for
+    any exposures which were offset in wavelength.
 
     Args:
         datadir (str): Path to directory with raw timeseries datasets
+        tss_params (dict): A dictionary where keys are the TSS parameters and
+            values are the parameter values, e.g. files to use.
         custom_caldir (str): Path to output directory
 
     Returns:
-        custom_caldir: Path to output directory with custom data products
+        custom_caldir: Path to output directory with custom data products.
+            Sometimes this directory is created on the fly.
     """
 
     calrequired0 = []
@@ -130,12 +244,14 @@ def calibrate_data(datadir, tss_params, custom_caldir=None):
     return custom_caldir
 
 
-def copy_caldata(datadir, tss_params, custom_caldir=None):
+def copy_monitoring_caldata(datadir, tss_params, custom_caldir=None):
     """
-    Copy the products for each target.
+    Copy the calibrated products for each target (corrtags and x1ds).
 
     Args:
         datadir (str): Path to directory with timeseries datasets
+        tss_params (dict): A dictionary where keys are the TSS parameters and
+            values are the parameter values, e.g. files to use.
         custom_caldir (str): Path to directory with custom calcos outputs
 
     """
@@ -143,20 +259,20 @@ def copy_caldata(datadir, tss_params, custom_caldir=None):
     if custom_caldir is None:
         custom_caldir = os.path.join(datadir, "custom_calibration")
 
-    # Copy the custom calibrated output
+    # Copy any custom calibrated output
     corrs = glob.glob(os.path.join(custom_caldir, "*corrtag*"))
-    datadir_fuv = os.path.join(datadir, "g160m")
-    datadir_nuv = os.path.join(datadir, "g230l")
-    datadir_fuvx1d = os.path.join(datadir_fuv, "exp")
-    datadir_nuvx1d = os.path.join(datadir_nuv, "exp")
-    for d in [datadir_fuv, datadir_nuv, datadir_fuvx1d, datadir_nuvx1d]:
+    datadir_g160m = os.path.join(datadir, "g160m")
+    datadir_g230l = os.path.join(datadir, "g230l")
+    datadir_g160mx1d = os.path.join(datadir_g160m, "exp")
+    datadir_g230lx1d = os.path.join(datadir_g230l, "exp")
+    for d in [datadir_g160m, datadir_g230l, datadir_g160mx1d, datadir_g230lx1d]:
         if not os.path.exists(d):
             os.makedirs(d)
     for item in corrs:
         if fits.getval(item, "opt_elem") == "G160M":
-            d = datadir_fuv
+            d = datadir_g160m
         else:
-            d = datadir_nuv
+            d = datadir_g230l
 #        filename = os.path.basename(item)
 #        sptfile = filename.split("_")[0]+"_spt.fits"
 #        spt = os.path.join(datadir, sptfile)
@@ -179,9 +295,9 @@ def copy_caldata(datadir, tss_params, custom_caldir=None):
         ipppssoot = os.path.basename(orig_corrs[i])[:9]
         if orig_corrfiles[i] not in corrfiles and ipppss not in tss_params["bad_ipppss"] and ipppssoot not in tss_params["bad_ipppssoot"]:
             if fits.getval(orig_corrs[i], "opt_elem") == "G160M":
-                d = datadir_fuv
+                d = datadir_g160m
             else:
-                d = datadir_nuv
+                d = datadir_g230l
             shutil.copy(orig_corrs[i], d)
 
     x1ds = glob.glob(os.path.join(custom_caldir, "*x1d.fits"))
@@ -193,12 +309,12 @@ def copy_caldata(datadir, tss_params, custom_caldir=None):
         ipppssoot = os.path.basename(orig_x1ds[i])[:9]
         if orig_x1dfiles[i] not in x1dfiles and ipppss not in tss_params["bad_ipppss"] and ipppssoot not in tss_params["bad_ipppssoot"]:
             if fits.getval(orig_x1ds[i], "opt_elem") == "G160M":
-                d = datadir_fuv
+                d = datadir_g160m
             else:
-                d = datadir_nuv
+                d = datadir_g230l
             shutil.copy(orig_x1ds[i], os.path.join(d, "exp"))
 
-    print(f"\nCopied all corrtags and x1ds to\n\t {datadir}/g160m/ and g230l/\n")
+    print(f"\nCopied all corrtags and x1ds to\n\t {datadir}g160m/ and g230l/\n")
     
 
 def create_splittags(datadir, tss_params):
@@ -208,10 +324,12 @@ def create_splittags(datadir, tss_params):
 
     Args:
         datadir (str): Path to data directory
+        tss_params (dict): A dictionary where keys are the TSS parameters and
+            values are the parameter values, e.g. files to use.
     """
 
     bins = tss_params["bins"]
-    for grat in ["g160m", "g230l"]:
+    for grat in tss_params["gratings"]:
         for epoch_ippp in bins:
             splitdir = os.path.join(datadir, grat, f"{epoch_ippp}_split")
             time_bin = bins[epoch_ippp][grat]["time"]
@@ -230,7 +348,7 @@ def correct_vignetting(datadir):
     Correct for vignetting on the COS/NUV detector in the G230L/2950 mode.
 
     Args:
-        datadir (str):
+        datadir (str): Path to data directory.
 
     Returns:
         None
@@ -254,7 +372,7 @@ def correct_vignetting(datadir):
     print(f'\nApplied scaling factor to G230L/2950 NUVB data in {os.path.join(datadir, "g230l")}') 
 
 
-def create_timeseries(datadir, tss_outdir, targ, tss_params):
+def create_serendipitous_timeseries(datadir, tss_outdir, targ, tss_params):
     """
     Creates the timeseries high level science products for ULLYSES monitoring targets
     from the custom-calibrated and split data products.
@@ -263,10 +381,39 @@ def create_timeseries(datadir, tss_outdir, targ, tss_params):
         datadir (str): Path to input data
         tss_outdir (str): Path to time series data product output directory
         targ (str): Target name
+        tss_params (dict): A dictionary where keys are the TSS parameters and
+            values are the parameter values, e.g. files to use.
+    Returns:
+        tss_outdir (str): Path to input data, sometimes this is created on the fly.
+    """
+
+    ins = tss_params["instrument"]
+    for grat in tss_params["gratings"]: 
+        # Create the exposure level time-series spectra
+        outfile = os.path.join(tss_outdir, f"hlsp_ullyses_hst_{ins}_{targ}_{grat}_{VERSION.lower()}_tss.fits")
+        timeseries.process_files(grat.upper(), outfile, datadir, overwrite=True, ins=ins.upper()) 
+        
+    return tss_outdir
+
+
+
+def create_monitoring_timeseries(datadir, tss_outdir, targ, tss_params):
+    """
+    Creates the timeseries high level science products for ULLYSES monitoring targets
+    from the custom-calibrated and split data products.
+
+    Args:
+        datadir (str): Path to input data
+        tss_outdir (str): Path to time series data product output directory
+        targ (str): Target name
+        tss_params (dict): A dictionary where keys are the TSS parameters and
+            values are the parameter values, e.g. files to use.
+    Returns:
+        tss_outdir (str): Path to input data, sometimes this is created on the fly.
     """
 
     bins = tss_params["bins"]
-    for grat in ["g160m", "g230l"]:
+    for grat in tss_params["gratings"]:
         epoch_ippp = list(bins.keys())[0]
         wl_bin = bins[epoch_ippp][grat]["wave"]
         min_exptime = bins[epoch_ippp][grat]["min_exptime"]
@@ -288,15 +435,21 @@ def create_timeseries(datadir, tss_outdir, targ, tss_params):
 
 def move_input_epoch_data(datadir, tss_params):
     """
+    Move data from different epochs into different directories.
     Each monitoring star includes two epochs of data. The corrtags for each
     epoch need to be kept in separate directories because each epoch may have
     different time sampling. The code to create splittags takes as input a
     single directory, so to create splittags of different time intervals as a
     function of epoch, each epoch's corrtags must be in separate directories.
+
+    Args:
+        datadir (str): Path to input data
+        tss_params (dict): A dictionary where keys are the TSS parameters and
+            values are the parameter values, e.g. files to use.
     """
 
     bins = tss_params["bins"]
-    for grat in ["g160m", "g230l"]:
+    for grat in tss_params["gratings"]:
         singledir = os.path.join(datadir, grat)
         for epoch_ippp in bins:
             splitdir = os.path.join(singledir, f"{epoch_ippp}_split")
@@ -324,10 +477,15 @@ def move_output_epoch_data(datadir, tss_params):
     must be copied to a single directory to be made into TSS products. 
     The timeseries creation code requires all input files to be stored in a 
     single directory.
+
+    Args:
+        datadir (str): Path to input data
+        tss_params (dict): A dictionary where keys are the TSS parameters and
+            values are the parameter values, e.g. files to use.
     """
     
     bins = tss_params["bins"]
-    for grat in ["g160m", "g230l"]:
+    for grat in tss_params["gratings"]:
         single_splitdir = os.path.join(datadir, grat, "split")
         if not os.path.exists(single_splitdir):
             os.makedirs(single_splitdir)
@@ -339,28 +497,43 @@ def move_output_epoch_data(datadir, tss_params):
     print(f"\nMoved x1ds to a single directory to be made into TSS")
 
 
-def main(datadir, orig_datadir, tss_outdir, targ, yamlfile=None, custom_caldir=None):
+def serendipitous_star(datadir, tss_outdir, targ, yamlfile=None, custom_caldir=None):
+    if not os.path.exists(tss_outdir):
+        os.makedirs(tss_outdir)
+    tss_params = read_tss_yaml(targ, yamlfile)
+    tss_params = get_goodbad_exposures(tss_params)
+    # Not yet implemented because it's not needed so far.
+    #copy_serendipitous_origdata(datadir, orig_datadir, tss_params)
+    #calibrate_cos_data(datadir, tss_params, custom_caldir)
+    #copy_monitoring_caldata(datadir, tss_params, custom_caldir)
+    create_serendipitous_timeseries(datadir, tss_outdir, targ, tss_params)
+
+
+def monitoring_star(datadir, orig_datadir, tss_outdir, targ, yamlfile=None, custom_caldir=None):
     """
+    Main wrapper function to create TSS for a monitoring star.
     Performs the timeseries data product calibration and creation.
 
     Args:
-        datadir (str):
-        orig_datadir (str):
-        tss_outdir (str):
-        targ (str):
-        custom_caldir (str):
+        datadir (str): The path the original data will be copied to.
+        orig_datadir (str): Path to the original raw data
+        tss_outdir (str): Path to time series data product output directory
+        targ (str): Name of target. Must be the ULLYSES DP target name!!!
+        custom_caldir (str): Path to directory with custom calcos outputs
     """
 
+    if not os.path.exists(tss_outdir):
+        os.makedirs(tss_outdir)
     tss_params = read_tss_yaml(targ, yamlfile)
-    tss_params = get_bad_exposures(tss_params)
-    copy_origdata(datadir, orig_datadir, tss_params)
-    calibrate_data(datadir, tss_params, custom_caldir)
-    copy_caldata(datadir, tss_params, custom_caldir)
+    tss_params = get_goodbad_exposures(tss_params)
+    copy_monitoring_origdata(datadir, orig_datadir, tss_params)
+    calibrate_cos_data(datadir, tss_params, custom_caldir)
+    copy_monitoring_caldata(datadir, tss_params, custom_caldir)
     move_input_epoch_data(datadir, tss_params)
     create_splittags(datadir, tss_params)
     move_output_epoch_data(datadir, tss_params)
     correct_vignetting(datadir)
-    create_timeseries(datadir, tss_outdir, targ, tss_params)
+    create_monitoring_timeseries(datadir, tss_outdir, targ, tss_params)
 
 
 if __name__ == "__main__":

--- a/ullyses/timeseries.py
+++ b/ullyses/timeseries.py
@@ -702,7 +702,7 @@ if __name__ == "__main__":
     parser.add_argument("-i", "--indir", default=".",
                         help="Path to input directory with either default x1d files or split x1d files")
     parser.add_argument("-g", "--grating", 
-                        help="Grating to process. Either G160M or G230L")
+                        help="Grating to process")
     parser.add_argument("-o", "--outfile",
                         help="Name of output file")
     parser.add_argument("-w", "--wl", default=1, type=int,

--- a/ullyses/timeseries.py
+++ b/ullyses/timeseries.py
@@ -46,7 +46,7 @@ SECONDS_PER_DAY = 86400.0
 
 """
 
-def sort_split_x1ds(grating, indir=".", min_exptime=20.0):
+def sort_split_x1ds(ins, grating, indir=".", min_exptime=20.0):
     """Sort the split x1d files.    Select all files that match the
     pattern 'split_*_without.fits' and that match the grating and whose
     exposure time is greated than min_exptime, and sort them by expstart
@@ -70,13 +70,14 @@ def sort_split_x1ds(grating, indir=".", min_exptime=20.0):
     for file in x1dfiles:
         f1 = fits.open(file)
         this_grating = f1[0].header['OPT_ELEM']
-        if this_grating == grating:
+        this_ins = f1[0].header["INSTRUME"]
+        if this_grating == grating and this_ins == ins:
             good_list.append(file)
         f1.close()
     sorted_x1dlist = sort_x1dfiles(good_list, min_exptime=min_exptime)
     return sorted_x1dlist
 
-def sort_full_x1ds(grating, indir=".", min_exptime=20.0):
+def sort_full_x1ds(ins, grating, indir=".", min_exptime=20.0):
     """Sort the full x1d files.    Select all files that match the
     pattern '*_without.fits' and don't start with 'split', and that match
     the grating and whose exposure time is greated than min_exptime, and
@@ -103,13 +104,14 @@ def sort_full_x1ds(grating, indir=".", min_exptime=20.0):
             continue
         f1 = fits.open(file)
         this_grating = f1[0].header['OPT_ELEM']
-        if this_grating == grating:
+        this_ins = f1[0].header["INSTRUME"]
+        if this_grating == grating and this_ins == ins:
             good_list.append(file)
         f1.close()
     sorted_x1dlist = sort_x1dfiles(good_list, min_exptime=min_exptime)
     return sorted_x1dlist
 
-def sort_x1ds(grating, indir=".", min_exptime=20.0):
+def sort_x1ds(ins, grating, indir=".", min_exptime=20.0):
     """Sort the x1d files.    Select all files that match the
     pattern '*_without.fits' and that match
     the grating and whose exposure time is greater than min_exptime, and
@@ -134,7 +136,8 @@ def sort_x1ds(grating, indir=".", min_exptime=20.0):
     for file in x1dfiles:
         f1 = fits.open(file)
         this_grating = f1[0].header['OPT_ELEM']
-        if this_grating == grating:
+        this_ins = f1[0].header["INSTRUME"]
+        if this_grating == grating and this_ins == ins:
             good_list.append(file)
         f1.close()
     sorted_x1dlist = sort_x1dfiles(good_list, min_exptime=min_exptime)
@@ -192,7 +195,10 @@ def create_ensemble_segmentlist(grating, indir=".", wavelength_binning=1.0, ins=
     if ins == "COS":
         a = wrapper.Ullyses_COSSegmentList(grating, path=indir)
     elif ins == "STIS":
-        a = wrapper.Ullyses_STISSegmentList(grating, path=indir)
+        if grating in ["G230LB", "G230M", "G230LB", "G230MB", "G430L", "G430M", "G750L", "G750M"]:
+            a = wrapper.Ullyses_CCDSegmentList(grating, path=indir)
+        else:
+            a = wrapper.Ullyses_STISSegmentList(grating, path=indir)
     a.create_output_wavelength_grid()
     if wavelength_binning != 1:
         a.delta_wavelength = a.delta_wavelength * wavelength_binning
@@ -360,11 +366,15 @@ def process_files(grating, outfile, indir=".", wavelength_binning=1, min_exptime
     # Ullyses_COSSegmentLists have the Ullyses-specific get_target() and get_coords()
     # methods
     ensemble = create_ensemble_segmentlist(grating, indir, wavelength_binning, ins=ins)
+    # If there's only 1 matching file for hte specified grating, exit 
+    if len(ensemble.datasets) == 1:
+        print(f"SKIPPING: only one matching dataset for grating {grating}")
+        return
     # Rename all the x1d.fits files to remove the _x1d.fits ending so that
     # subsequent Ullyses_COSSegmentLists can be created one at a time
     renaming_old, renaming_new = rename_all_x1ds(indir)
     # create a list of split files sorted by expstart
-    sorted_files = sort_x1ds(grating, indir, min_exptime=min_exptime)
+    sorted_files = sort_x1ds(ins, grating, indir, min_exptime=min_exptime)
     # process this list of files one at a time to each write a single row
     # to the output flux and error arrays.  Write the output file when complete
     process_sorted_filelist(sorted_files, grating, ensemble, outfile, renaming_new, indir,
@@ -412,14 +422,18 @@ def process_sorted_filelist(sorted_list, grating, ensemble, outfile, renaming_ne
     if ins == "COS":
         segmentlist = wrapper.Ullyses_COSSegmentList
     elif ins == "STIS":
-        segmentlist = wrapper.Ullyses_STISSegmentList
+        if grating in ["G230LB", "G230M", "G230LB", "G230MB", "G430L", "G430M", "G750L", "G750M"]:
+            segmentlist = wrapper.Ullyses_CCDSegmentList
+        else:
+            segmentlist = wrapper.Ullyses_STISSegmentList
     for newfile, expstart in sorted_list:
         oldfile = renaming_new[newfile]
         os.rename(newfile, oldfile)
         # Make sure this file uses the required grating
         f1 = fits.open(oldfile)
         this_grating = f1[0].header['OPT_ELEM']
-        if this_grating != grating:
+        this_ins = f1[0].header["INSTRUME"]
+        if this_grating != grating and this_ins != ins:
             print(f"Skipping file {newfile} as it doesn't have the required grating")
             f1.close()
             continue

--- a/ullyses/wrapper.py
+++ b/ullyses/wrapper.py
@@ -30,6 +30,12 @@ class Ullyses_SegmentList(SegmentList):
 
     """
 
+    # Segments that should be ignored for each cenwave.
+    # For ULLYSES this is G230L/2635/NUVC and G230L/2950/NUVC
+#    self.bad_segments = {2635: 'NUVC', 2950: 'NUVC'}
+    SegmentList.bad_segments = {2635: 'NUVC', 2950: 'NUVC'}
+    
+
     def write(self, filename, overwrite=False, level="", version=""):
 
         # If the target is a ULLYSES target, use the official


### PR DESCRIPTION
Changes include

- coadd.py: specifying the "bad segments" for COS/NUV data, so that other NUV data can be used as is.
- ctts_cal.py: Substantial updates to all functions, including generalizing a lot of stuff so it works with non-monitoring star gratings, and duplicating some functions for more general use.
- timeseries.py: always check instrument AND grating, since COS and STIS both have a G230L grating.