### PR TITLE
Add fix for HASP data sometimes creating a product with no good pixels

### DIFF
--- a/ullyses/coadd.py
+++ b/ullyses/coadd.py
@@ -344,8 +344,13 @@ class FUSESegmentList(SegmentList):
         nonzeros = np.where(self.output_errors != 0.0)
         self.signal_to_noise[nonzeros] = self.output_flux[nonzeros] / self.output_errors[nonzeros]
         good_dq = np.where(self.output_exptime > 0.)
-        self.first_good_wavelength = self.output_wavelength[good_dq][0]
-        self.last_good_wavelength = self.output_wavelength[good_dq][-1]
+        if len(good_dq[0]) > 0:
+            self.first_good_wavelength = self.output_wavelength[good_dq][0]
+            self.last_good_wavelength = self.output_wavelength[good_dq][-1]
+        else:
+            self.first_good_wavelength = None
+            self.last_good_wavelength = None
+            print('No good data in product')
         return
 
 class CCDSegmentList(SegmentList):
@@ -430,8 +435,13 @@ class CCDSegmentList(SegmentList):
             nonzeros = np.where(self.output_errors != 0.0)
             self.signal_to_noise[nonzeros] = self.output_flux[nonzeros] / self.output_errors[nonzeros]
             good_dq = np.where(self.output_exptime > 0.)
-            self.first_good_wavelength = self.output_wavelength[good_dq][0]
-            self.last_good_wavelength = self.output_wavelength[good_dq][-1]
+            if len(good_dq[0]) > 0:
+                self.first_good_wavelength = self.output_wavelength[good_dq][0]
+                self.last_good_wavelength = self.output_wavelength[good_dq][-1]
+            else:
+                self.first_good_wavelength = None
+                self.last_good_wavelength = None
+                print('No good data in product')
         else:
             nelements = len(self.output_wavelength)
             self.output_sumsqerrors = np.zeros(nelements)
@@ -449,8 +459,13 @@ class CCDSegmentList(SegmentList):
                     self.output_sumsqerrors[indices[i]] = self.output_sumsqerrors[indices[i]] + (err[i] * weight[i])**2
                     self.output_exptime[indices[i]] = self.output_exptime[indices[i]] + segment.exptime
             good_dq = np.where(self.output_exptime > 0.)
-            self.first_good_wavelength = self.output_wavelength[good_dq][0]
-            self.last_good_wavelength = self.output_wavelength[good_dq][-1]
+            if len(good_dq[0]) > 0:
+                self.first_good_wavelength = self.output_wavelength[good_dq][0]
+                self.last_good_wavelength = self.output_wavelength[good_dq][-1]
+            else:
+                self.first_good_wavelength = None
+                self.last_good_wavelength = None
+                print('No good data in product')
             nonzeros = np.where(self.output_sumweight != 0)
             self.output_flux[nonzeros] = self.output_sumflux[nonzeros] / self.output_sumweight[nonzeros]
             self.output_errors[nonzeros] = np.sqrt(self.output_sumsqerrors[nonzeros]) / self.output_sumweight[nonzeros]

--- a/ullyses/coadd.py
+++ b/ullyses/coadd.py
@@ -191,8 +191,11 @@ class SegmentList:
             weight = flux_weight[goodpixels]
             net_counts = segment.data['net'][goodpixels] * segment.exptime
             if self.instrument == 'COS':
-                variances = segment.data['variance_counts'][goodpixels] + segment.data['variance_bkg'][goodpixels] + segment.data['variance_flat'][goodpixels]
-
+                try:
+                    variances = segment.data['variance_counts'][goodpixels] + segment.data['variance_bkg'][goodpixels] + segment.data['variance_flat'][goodpixels]
+                except KeyError:
+                    print('WARNING: Cant get variance keywords for COS data, using gross counts instead')
+                    variances = gcounts
             flux = segment.data['flux'][goodpixels]
             for i in range(npts):
                 self.sumnetcounts[indices[i]] = self.sumnetcounts[indices[i]] + net_counts[i]
@@ -405,7 +408,7 @@ class CCDSegmentList(SegmentList):
 
             self.delta_wavelength = max_delta_wavelength
 
-            wavegrid = np.arange(self.min_wavelength, self.max_wavelength, self.delta_wavelength)
+            wavegrid = np.arange(self.min_wavelength, self.max_wavelength+self.delta_wavelength, self.delta_wavelength)
 
             self.output_wavelength = wavegrid
 


### PR DESCRIPTION
When the coadd code creates a product with no good pixels (all have effective_exptime = 0.0), the code will throw an exception when trying to calculate the first and last good wavelengths.  This sometimes happens for HASP STIS data, but not for Ullyses data as the preprocessing of STIS data takes care of this.  To fix, the first and last good wavelengths are set to None if there are no good pixels.  The HASP wrapper code detects this and doesn't try to make a product in such a case, but I didn't add a handler to the Ullyses wrapper since the case doesn't occur (and perhaps throwing an exception is preferred to raise visibility to this case). 