### PR TITLE
Fix problem with output data overflowing output array

### DIFF
--- a/ullyses/coadd.py
+++ b/ullyses/coadd.py
@@ -157,7 +157,7 @@ class SegmentList:
 
         self.delta_wavelength = max_delta_wavelength
 
-        wavegrid = np.arange(self.min_wavelength, self.max_wavelength, self.delta_wavelength)
+        wavegrid = np.arange(self.min_wavelength, self.max_wavelength + self.delta_wavelength, self.delta_wavelength)
 
         self.output_wavelength = wavegrid
         self.nelements = len(wavegrid)


### PR DESCRIPTION
This is the same fix that was applied to STIS CCD data in #47.  I didn't expect it to be a problem for COS data, but we have seen some NUV data overflow the output array and this small change fixes the problem