### PR TITLE
Change extension of level3 products from cspec to aspec

### DIFF
--- a/ullyses/wrapper.py
+++ b/ullyses/wrapper.py
@@ -578,15 +578,17 @@ def create_output_file_name(prod, version=VERSION, level=3):
     if level == 1:
         suffix = "mspec"
         tel = 'hst'
-    elif level == 3 or level == 2:
+    elif level == 2:
+        tel= 'hst'
+        suffix = "cspec"
+    elif level == 3:
         if instrument == 'fuse':
             tel = 'fuse'
             instrument = 'fuv'   # "fuv" is the "instrument" equivalent for fuse
             grating = aperture   # the grating for fuse data is set to "fuse" to change to use aperture
-            suffix = 'cspec'
         else:
             tel= 'hst'
-            suffix = "cspec"
+        suffix = 'aspec'
     elif level == 4:
         suffix = "preview-spec"
         if "G430L" in prod.grating or "G750L" in prod.grating:


### PR DESCRIPTION
I tested this on a sample dataset and the only other changes than the suffix are from other post-DR6 merged changes.