### PR TITLE
Updates to support creation of XSU HLSPs

### DIFF
--- a/ullyses/create_ullyses_hlsp.py
+++ b/ullyses/create_ullyses_hlsp.py
@@ -44,7 +44,7 @@ def make_lcogt_tss(indir, outdir, targ, hlspname=None, photfile=None):
     aliases = parse_aliases()
     alias_mask = aliases.apply(lambda row: row.astype(str).str.fullmatch(re.escape(targ.upper())).any(), axis=1)
     if set(alias_mask) != {False}:
-        ull_targname = aliases[alias_mask]["ULL_MAST_name"].values[0]
+        ull_targname = aliases[alias_mask]["target_name_hlsp"].values[0]
         targetinfo_file = os.path.join(UTILS_DIR, "data", "target_metadata", "pd_targetinfo.json")
         master_list = pd.read_json(targetinfo_file, orient="split")
         master_list = master_list.apply(lambda x: x.astype(str).str.upper())

--- a/ullyses/ullyses_hlsp.py
+++ b/ullyses/ullyses_hlsp.py
@@ -13,6 +13,7 @@ import sys
 from ullyses_utils.parse_csv import parse_aliases
 from ullyses_utils.ullyses_config import VERSION, CAL_VER
 
+SECONDS_PER_DAY = 86400.
 CODEDIR = os.path.dirname(__file__)
 RED = "\033[1;31m"
 RESET = "\033[0;0m"
@@ -817,11 +818,11 @@ class Ullyses():
                             val = mjdstart
                         if k == "expend":
                             exptime = self.first_headers[i]["exptime"]
-                            val = mjdstart + (exptime/86400) # seconds in a day
+                            val = mjdstart + (exptime / SECONDS_PER_DAY) 
                     case ["VLT", "expend"]:
                         mjdstart = self.first_headers[i]["mjd-obs"]
                         exptime = self.first_headers[i]["exptime"]
-                        val = mjdstart + (exptime/86400) # seconds in a day
+                        val = mjdstart + (exptime / SECONDS_PER_DAY) 
                     case ["VLT", "minwave" | "maxwave" | "cenwave" as k]:
                         if self.first_headers[i]["arm"] == "UVB":
                             wave_vals = {"minwave": 3000, "maxwave": 5551, "cenwave": 4276}


### PR DESCRIPTION
This takes as input an XSU data product and reformats it as a ULLYSES HLSP. This involves:
- taking as input the XSU *INDIV1D*REBIN* fits files
- making a completely new primary header
- not touching any data in all SCI extensions
- adding just a few required keywords to SCI extension headers, but otherwise leaving all VLT keys intact
- adding a provenance extension

The number of SCI extensions in XSU data can vary, but it is always at least 2. These products are classified as new HLSP_LVL=7 products (community-submitted HLSPs).

I verified that updates to `ullyses_hlsp.py` do not create any changes to drizzled and LCOGT HLSPs which also make use of this script. 

Testing was performed using two targets from XSU: PGMW3120 & AV-451, and was done like so:
```
from ullyses_hlsp import Ullyses
U = Ullyses(files=["in_xsu/XSH-U_AV251_INDIV1D_REBIN.fits"],
hlspname="out_xsu/hlsp_ullyses_vlt_xshooter_av-251_uvb-vis_dr7_aspec.fits",
targname="AV-451",
ra=100.0, dec=101.0,
level=7,
cal_ver="1.2.3", version="dr7",
hlsp_type="xsu", overwrite=True)
U.make_hdrs_and_prov()
U.write_file()

U = Ullyses(files=["in_xsu/XSH-U_PGMW3120_INDIV1D_REBIN.fits"],
hlspname="out_xsu/hlsp_ullyses_vlt_xshooter_pgmw-3120_uvb-vis_dr7_aspec.fits",
targname="PGMW-3120",
ra=100.0, dec=101.0,
level=7,
cal_ver="1.2.3", version="dr7",
hlsp_type="xsu", overwrite=True)
U.make_hdrs_and_prov()
U.write_file()
```

(dummy RA & dec values were used for testing but will be properly selected when creating final HLSPs)