### PR TITLE
Sort the provenance extension in ascending time order

### DIFF
--- a/ullyses/wrapper.py
+++ b/ullyses/wrapper.py
@@ -159,7 +159,18 @@ class Ullyses_SegmentList(SegmentList):
         cmin = fits.Column(name='MINWAVE', array=self.combine_keys("minwave", "arr"), format='F9.4', unit='Angstrom')
         cmax = fits.Column(name='MAXWAVE', array=self.combine_keys("maxwave", "arr"), format='F9.4', unit='Angstrom')
 
-        cd2 = fits.ColDefs([cfn, cpid, ctel, cins, cdet, cdis, ccen, cap, csr, ccv, cdb, cdm, cde, cexp, cmin ,cmax])
+        ## sort the provenance by MJD start time
+        time_sort = np.argsort(cdb.array) # indices
+        # sort each of the columns using these indices
+        col_in_order = [cfn, cpid, ctel, cins, cdet, cdis, ccen, cap, csr, ccv,
+                        cdb, cdm, cde, cexp, cmin, cmax]
+        sorted_coldef = []
+        for col in col_in_order:
+            col.array = col.array[time_sort]
+            sorted_coldef.append(col)
+
+        # turn into a ColDef to feed into the HDU
+        cd2 = fits.ColDefs(sorted_coldef)
 
         table2 = fits.BinTableHDU.from_columns(cd2, header=hdr2)
 


### PR DESCRIPTION
I tested this on several files, and it appears to be doing what I expect it to be doing:
<img width="1366" alt="Screen Shot 2023-10-25 at 5 24 07 PM" src="https://github.com/spacetelescope/ullyses/assets/10998234/294fcada-0906-4232-8213-f7b9bba631c9">

@stscirij and @jotaylor let me know if it looks like I broke anything crazy!

The files I created are in: /user/rplesha/hlsp if you would like to take a look at them yourself.