### PR TITLE
Add gratings to level3 list, use new HASP abut as well

### DIFF
--- a/src/ullyses/ullyses_coadd_abut_wrapper.py
+++ b/src/ullyses/ullyses_coadd_abut_wrapper.py
@@ -430,9 +430,9 @@ def coadd_and_abut_files(infiles, outdir, version=__release__, clobber=False):
             prod.write(outname, clobber, level=0, version=version)
             print(f"   Wrote {outname}")
             products[f'{instrument}/{grating}'] = prod
+        prod.add_hasp_attributes()
         products[f'{instrument}/{grating}'] = prod
         productdict[f'{instrument}/{grating}'] = prod
-        prod.add_hasp_attributes()
 
     # Create level 3 products- abutted spectra for gratings of the same
     # resolution for each instrument. Only create this product if more than
@@ -452,6 +452,8 @@ def coadd_and_abut_files(infiles, outdir, version=__release__, clobber=False):
                 lvl3_productlist.append(products[mode])
                 lvl3_productdict[mode] = products[mode]
                 dowrite = True
+        # We only write level 3 products if more than one grating was found per resolution
+        # group
         if dowrite is True and len(lvl3_productlist) > 1:
             lvl3_product = create_level4_products(lvl3_productlist, lvl3_productdict,
                                              grating_table=ULLYSES_GRATING_PRIORITIES)

--- a/src/ullyses/ullyses_coadd_abut_wrapper.py
+++ b/src/ullyses/ullyses_coadd_abut_wrapper.py
@@ -435,27 +435,32 @@ def coadd_and_abut_files(infiles, outdir, version=__release__, clobber=False):
         prod.add_hasp_attributes()
 
     # Create level 3 products- abutted spectra for gratings of the same
-    # resolution for each instrument.
+    # resolution for each instrument. Only create this product if more than
+    # one grating of each resolution group is detected.
     level = 3
-    lvl3_modes = {"cos_fuv_m": ["COS/G130M", "COS/G160M", "COS/G185M"],
-                  "stis_m": ["STIS/E140M", "STIS/E230M"],
+    lvl3_modes = {"cos_fuv_m": ["COS/G130M", "COS/G160M", "COS/G185M", "COS/G285M", "COS/G225M"],
+                  "stis_m": ["STIS/E140M", "STIS/E230M", "STIS/G230MB", "STIS/G140M", "STIS/G230M", "STIS/G750M", "STIS/G430M"],
                   "stis_h": ["STIS/E140H", "STIS/E230H"],
-                  "stis_l": ["STIS/G140L", "STIS/G230L", "STIS/G430L", "STIS/G750L"]}
+                  "stis_l": ["STIS/G140L", "STIS/G230L", "STIS/G230LB", "STIS/G430L", "STIS/G750L"],
+                  }
     for outprod,modes in lvl3_modes.items():
-        abutted = None
+        lvl3_productlist = []
+        lvl3_productdict = {}
         dowrite = False
         for mode in modes:
             if products[mode] is not None:
-                if abutted is None:
-                    abutted = products[mode]
-                else:
-                    abutted = abut(abutted, products[mode])
-                    dowrite = True
-        if dowrite is True:
-            filename = create_output_file_name(abutted, version, level=level)
+                lvl3_productlist.append(products[mode])
+                lvl3_productdict[mode] = products[mode]
+                dowrite = True
+        if dowrite is True and len(lvl3_productlist) > 1:
+            lvl3_product = create_level4_products(lvl3_productlist, lvl3_productdict,
+                                             grating_table=ULLYSES_GRATING_PRIORITIES)
+            filename = create_output_file_name(lvl3_product, version, level=level)
             filename = os.path.join(outdir, filename)
-            abutted.write(filename, clobber, level=level, version=version)
+            lvl3_product.write(filename, clobber, level=level, version=version)
             print(f"   Wrote {filename}")
+
+
     # Manually write out a FUSE level3 product.
     if products['FUSE/FUSE'] is not None:
         filename = create_output_file_name(products['FUSE/FUSE'], version, level=level)


### PR DESCRIPTION
We only used the new HASP abut strategy for level 4 (preview-spec) products. We neglected to use it also for level 3 (aspec). Because of this, aspecs were being created in the same method as previous DRs. The gratings that contribute to each aspec were hardcoded, because they are grouped by resolution. However, as we added more non-ULLYSES data (i.e. AR data), we did not update this hardcoded list. This led to some AR modes not being included in aspecs. 

There were two solutions. 1) Simply add the missing gratings to the hardcoded list. This does not address the issues that level 3 products are using the old abut strategy.
2) Add missing gratings to hardcoded list AND use new abut strategy. This is what I did. *Note that I also followed the currently implemented logic which is to NOT make an aspec when only 1 mode exists for a resolution grouping. I checked with ULLYSES leads that this behavior is desired for aspecs. 

I have tested 3 example cases: 1 where we were missing 2 modes (AV-304), one where no modes were missing (AV-456), and one where only 1 grating contributes to the target at all (CVSO-35). They all changed as expected which is:
- AV-304 included the missing modes in aspecs now (including a completely new aspec file). All other files identical.
- AV-456 only changed in the aspec files, and all that changed was the transition points because we are now using HASP strategy. All other files identical.
- CVSO-35 did not change at all because it has no aspecs. All files identical.